### PR TITLE
feat: add proxy configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ npm install
 1. Edit file tbb-checkout-instore-custom.js and commit on this project.
 2. Copy the the value of this file on: https://instoretbb.vtexcommercestable.com.br/admin/portal/#/sites/default/code/files/checkout-instore-custom.js
 
-
 ## Doc
 
 > A little explanation about each config.
@@ -24,3 +23,7 @@ In the `ProductPage` we have a freigth table that contains informations about th
 
 This feature enables regionalization to improve search products prioritizing taking into account the availability of stock in sellers white labels that attends client address.
 Only for VTEX Intelligent Search's clients.
+
+### Proxy configuration
+
+In proxy-config-example you can configure a proxy for Electron App that will be used in the normal requests with `fetch`, `splunk` and `EventSource`.

--- a/proxy-config-example.js
+++ b/proxy-config-example.js
@@ -1,0 +1,6 @@
+// The following configuration enable a host/post to set a proxy for Electron App requests, like splunk, EventSource and fetchs
+
+window.INSTORE_CONFIG = {
+  // ...
+  proxy: 'http://127.0.0.1:8888',
+}


### PR DESCRIPTION
In proxy-config-example you can configure a proxy for Electron App that will be used in the normal requests with `fetch`, `splunk` and `EventSource`.